### PR TITLE
Display XP instead of level

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ You can control the appearance of your badge using query parameters:
   /api/code-stats?user=yourusername&showProgressBar=false
   ```
 
+- **Display language XP instead of level:**  
+  Use `showLangXP=true` to show XP for each language instead of the level.  
+  Example:
+
+  ```
+  /api/code-stats?user=yourusername&showLangXP=true
+  ```
+
 - **Theme (light or dark):**  
   Use `theme=light` for a light background, or `theme=dark` for a dark background (default is dark).  
   Example:
@@ -102,7 +110,7 @@ This project works great on:
 
 - Font choices
 - Customizable color palette via query parameters
-- Option to display language XP instead of level
+
 - Support for compact/minimal badge layout
 - Add last updated timestamp
 

--- a/api/code-stats.js
+++ b/api/code-stats.js
@@ -2,7 +2,7 @@ import { getCodeStatsSVG } from "../src/codeStatsService.js";
 import { validateRequest } from "../src/utils.js";
 
 export default async function handler(req, res) {
-  const { user: username, limit, showProgressBar, theme } = req.query;
+  const { user: username, limit, showProgressBar, theme, showLangXP } = req.query;
   const themeValue = theme || "dark";
 
   const validation = validateRequest({ username, theme: themeValue });
@@ -16,6 +16,7 @@ export default async function handler(req, res) {
       limit,
       showProgressBar: showProgressBar !== "false",
       theme: themeValue,
+      showLangXP: showLangXP === "true",
     });
     res.setHeader("Content-Type", "image/svg+xml");
     res.setHeader("Content-Disposition", 'inline; filename="badge.svg"');

--- a/api/tests/code-stats.test.js
+++ b/api/tests/code-stats.test.js
@@ -49,6 +49,7 @@ describe("api/code-stats.js handler", () => {
       limit: "2",
       showProgressBar: true,
       theme: "dark",
+      showLangXP: false,
     });
     expect(res.setHeader).toHaveBeenCalledWith("Content-Type", "image/svg+xml");
     expect(res.setHeader).toHaveBeenCalledWith(
@@ -86,6 +87,7 @@ describe("api/code-stats.js handler", () => {
     expect(getCodeStatsSVG).toHaveBeenCalledWith("testuser", {
       showProgressBar: false,
       theme: "dark",
+      showLangXP: false,
     });
   });
 
@@ -97,6 +99,7 @@ describe("api/code-stats.js handler", () => {
     expect(getCodeStatsSVG).toHaveBeenCalledWith("testuser", {
       showProgressBar: true,
       theme: "dark",
+      showLangXP: false,
     });
   });
 
@@ -108,6 +111,7 @@ describe("api/code-stats.js handler", () => {
     expect(getCodeStatsSVG).toHaveBeenCalledWith("testuser", {
       showProgressBar: true,
       theme: "dark",
+      showLangXP: false,
     });
   });
 
@@ -119,8 +123,35 @@ describe("api/code-stats.js handler", () => {
     expect(getCodeStatsSVG).toHaveBeenCalledWith("testuser", {
       showProgressBar: true,
       theme: "light",
+      showLangXP: false,
     });
   });
+
+  it("defaults theme to dark if not provided", async () => {
+    getCodeStatsSVG.mockResolvedValue("<svg>test</svg>");
+    const req = { query: { user: "testuser" } };
+    const res = createRes();
+    await handler(req, res);
+    expect(getCodeStatsSVG).toHaveBeenCalledWith("testuser", {
+      showProgressBar: true,
+      theme: "dark",
+      showLangXP: false,
+    });
+  });
+
+  it("passes showLangXP if provided", async () => {
+    getCodeStatsSVG.mockResolvedValue("<svg>test</svg>");
+    const req = { query: { user: "testuser", showLangXP: "true" } };
+    const res = createRes();
+    await handler(req, res);
+    expect(getCodeStatsSVG).toHaveBeenCalledWith("testuser", {
+      showProgressBar: true,
+      theme: "dark",
+      showLangXP: true,
+    });
+  });
+
+
 
   it("returns 400 if theme is invalid", async () => {
     const req = { query: { user: "testuser", theme: "blue" } };

--- a/src/codeStatsService.js
+++ b/src/codeStatsService.js
@@ -3,7 +3,7 @@ import { calculateLevel, generateSVG } from "./svg.js";
 
 export async function getCodeStatsSVG(username, options = {}) {
   if (!username) throw new Error("Missing username");
-  const { limit = 6, showProgressBar = true, theme = "dark" } = options;
+  const { limit = 6, showProgressBar = true, theme = "dark", showLangXP = false } = options;
 
   const langLimit = Math.max(1, Math.min(20, parseInt(limit) || 6));
   const { data } = await axios.get(
@@ -18,7 +18,12 @@ export async function getCodeStatsSVG(username, options = {}) {
     }))
     .sort((a, b) => b.xp - a.xp)
     .slice(0, langLimit);
-  return generateSVG(username, totalXP, languages, { showProgressBar, theme });
+  return generateSVG(
+    username,
+    totalXP,
+    languages,
+    { showProgressBar, theme, showLangXP }
+  );
 }
 
 export function validateTheme(theme) {

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ const app = express();
 const PORT = process.env.PORT || 3000;
 
 app.get("/api/code-stats", async (req, res) => {
-  const { user: username, limit, showProgressBar, theme } = req.query;
+  const { user: username, limit, showProgressBar, theme, showLangXP } = req.query;
   const themeValue = theme || "dark";
 
   const validation = validateRequest({ username, theme: themeValue });
@@ -20,6 +20,7 @@ app.get("/api/code-stats", async (req, res) => {
       limit,
       showProgressBar: showProgressBar !== "false",
       theme: themeValue,
+      showLangXP: showLangXP === "true",
     });
     res.setHeader("Content-Type", "image/svg+xml");
     res.setHeader("Cache-Control", "s-maxage=3600");

--- a/src/svg.js
+++ b/src/svg.js
@@ -34,7 +34,7 @@ const THEMES = {
 };
 
 export function generateSVG(username, totalXP, topLangs, style = {}) {
-  const { showProgressBar = true, theme = "dark" } = style;
+  const { showProgressBar = true, theme = "dark", showLangXP = false } = style;
 
   const palette = THEMES[theme] || THEMES.dark;
 
@@ -65,7 +65,10 @@ export function generateSVG(username, totalXP, topLangs, style = {}) {
       const row = Math.floor(i / 2);
       const x = 10 + col * colWidth;
       const y = langStartY + row * rowHeight;
-      return `<text x="${x}" y="${y}" font-size="14" fill="${palette.text}" class="lang-line">${lang.name}: Level ${lang.level}</text>`;
+      const value = showLangXP
+        ? `${formatNumber(lang.xp)} XP`
+        : `Level ${lang.level}`;
+      return `<text x="${x}" y="${y}" font-size="14" fill="${palette.text}" class="lang-line">${lang.name}: ${value}</text>`;
     })
     .join("");
 
@@ -79,12 +82,11 @@ export function generateSVG(username, totalXP, topLangs, style = {}) {
       <text x="50%" y="25" font-size="16" fill="${palette.title}" text-anchor="middle" class="title">Code::Stats</text>
       <text x="50%" y="45" font-size="14" fill="${palette.text}" text-anchor="middle">${username} (Level ${level} – ${formatNumber(progressToNext)} XP to next)</text>
       <text x="10" y="65" font-size="14" fill="${palette.label}">Total XP: ${formatNumber(totalXP)}</text>
-      ${
-        showProgressBar
-          ? `<rect x="10" y="75" width="380" height="10" fill="${palette.progressBg}" rx="5"/>
+      ${showProgressBar
+      ? `<rect x="10" y="75" width="380" height="10" fill="${palette.progressBg}" rx="5"/>
              <rect x="10" y="75" width="${Math.round(3.8 * progressPercentage)}" height="10" fill="${palette.progress}" rx="5"/>`
-          : ""
-      }
+      : ""
+    }
       ${langLines}
     </svg>`;
 }


### PR DESCRIPTION
## Description

Ability to have the language XP be shown instead of the level

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if relevant)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

## Screenshots (if applicable)

<img width="396" height="177" alt="Screenshot 2025-07-13 at 17 49 38" src="https://github.com/user-attachments/assets/d5cf443e-bcbb-46d9-a2b2-f2e3f9d78a27" />
