### PR TITLE
Add borderless option for the badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ You can control the appearance of your badges using query parameters:
 
   ![Compact Code::Stats](https://codestats-badge.vercel.app/api/code-stats?user=Wallyx&compact=true)
 
+- **Borderless mode:**  
+  Use `borderless=true` to remove the badge's outer border for a cleaner look.  
+  Example:
+
+  ```
+  /api/code-stats?user=yourusername&borderless=true
+  ```
+
+  ![Borderless Code::Stats](https://codestats-badge.vercel.app/api/code-stats?user=Wallyx&borderless=true)
+
 ### Activity Badge:
 
 - **Theme (light or dark):**  
@@ -81,6 +91,16 @@ You can control the appearance of your badges using query parameters:
   ```
 
   ![Activity Code::Stats](https://codestats-badge.vercel.app/api/code-stats/activity?user=Wallyx&theme=light)
+
+- **Borderless mode:**  
+  Use `borderless=true` to remove the badge's outer border for a cleaner look.  
+  Example:
+
+  ```
+  /api/code-stats/activity?user=yourusername&borderless=true
+  ```
+
+  ![Borderless Activity Code::Stats](https://codestats-badge.vercel.app/api/code-stats/activity?user=Wallyx&borderless=true)
 
 ## 💻 Local Development
 

--- a/app/api/code-stats/activity/route.js
+++ b/app/api/code-stats/activity/route.js
@@ -7,6 +7,7 @@ export async function GET(request) {
     const { searchParams } = new URL(request.url);
     const username = searchParams.get("user");
     const theme = searchParams.get("theme") || "dark";
+    const borderless = searchParams.get("borderless") === "true";
 
     const validation = validateRequest({ username, theme });
     if (!validation.valid) {
@@ -16,7 +17,7 @@ export async function GET(request) {
 
     try {
         const dailyExperience = await getDailyExperience(username);
-        const svg = generateActivitySVG(dailyExperience, theme);
+        const svg = generateActivitySVG(dailyExperience, theme, new Date(), borderless);
 
         return new NextResponse(svg, {
             status: 200,

--- a/app/api/code-stats/activity/tests/route.test.js
+++ b/app/api/code-stats/activity/tests/route.test.js
@@ -44,7 +44,9 @@ describe("GET /api/code-stats/activity", () => {
                 { date: "2026-02-02", xp: 200 },
                 { date: "2026-02-03", xp: 50 },
             ],
-            "dark"
+            "dark",
+            expect.any(Date),
+            false
         );
 
         expect(res.status).toBe(200);
@@ -64,13 +66,55 @@ describe("GET /api/code-stats/activity", () => {
                 { date: "2026-02-02", xp: 200 },
                 { date: "2026-02-03", xp: 50 },
             ],
-            "light"
+            "light",
+            expect.any(Date),
+            false
         );
 
         expect(res.status).toBe(200);
         expect(res.headers.get("Content-Type")).toBe("image/svg+xml");
         const body = await res.text();
         expect(body).toBe("<svg>mocked</svg>");
+    });
+
+    it("returns SVG with borderless=true if borderless is set to true", async () => {
+        const req = { url: "http://localhost/api/code-stats/activity?user=testuser&borderless=true" };
+        const res = await GET(req);
+
+        expect(getDailyExperience).toHaveBeenCalledWith("testuser");
+        expect(generateActivitySVG).toHaveBeenCalledWith(
+            [
+                { date: "2026-02-01", xp: 100 },
+                { date: "2026-02-02", xp: 200 },
+                { date: "2026-02-03", xp: 50 },
+            ],
+            "dark",
+            expect.any(Date),
+            true
+        );
+
+        expect(res.status).toBe(200);
+        expect(res.headers.get("Content-Type")).toBe("image/svg+xml");
+        const body = await res.text();
+        expect(body).toBe("<svg>mocked</svg>");
+    });
+
+    it("defaults borderless to false if not set", async () => {
+        const req = { url: "http://localhost/api/code-stats/activity?user=testuser" };
+        const res = await GET(req);
+
+        expect(generateActivitySVG).toHaveBeenCalledWith(
+            [
+                { date: "2026-02-01", xp: 100 },
+                { date: "2026-02-02", xp: 200 },
+                { date: "2026-02-03", xp: 50 },
+            ],
+            "dark",
+            expect.any(Date),
+            false
+        );
+
+        expect(res.status).toBe(200);
     });
 
     it("returns 500 on error", async () => {

--- a/app/api/code-stats/badge/route.js
+++ b/app/api/code-stats/badge/route.js
@@ -10,6 +10,7 @@ export async function GET(request) {
     const theme = searchParams.get("theme") || "dark";
     const showLangXP = searchParams.get("showLangXP");
     const compact = searchParams.get("compact");
+    const borderless = searchParams.get("borderless");
 
     const validation = validateRequest({ username, theme });
     if (!validation.valid) {
@@ -23,6 +24,7 @@ export async function GET(request) {
             theme,
             showLangXP: showLangXP === "true",
             compact: compact === "true",
+            borderless: borderless === "true",
         });
         return new NextResponse(svg, {
             status: 200,

--- a/app/api/code-stats/badge/tests/route.test.js
+++ b/app/api/code-stats/badge/tests/route.test.js
@@ -35,6 +35,7 @@ describe("GET handler", () => {
       theme: "dark",
       showLangXP: false,
       compact: false,
+      borderless: false,
     });
     expect(res.status).toBe(200);
     expect(res.headers.get("Content-Type")).toBe("image/svg+xml");
@@ -64,6 +65,7 @@ describe("GET handler", () => {
       theme: "dark",
       showLangXP: false,
       compact: false,
+      borderless: false,
     });
   });
 
@@ -77,6 +79,7 @@ describe("GET handler", () => {
       theme: "dark",
       showLangXP: false,
       compact: false,
+      borderless: false,
     });
   });
 
@@ -90,6 +93,7 @@ describe("GET handler", () => {
       theme: "dark",
       showLangXP: false,
       compact: false,
+      borderless: false,
     });
   });
 
@@ -103,6 +107,7 @@ describe("GET handler", () => {
       theme: "dark",
       showLangXP: false,
       compact: false,
+      borderless: false,
     });
   });
 
@@ -116,6 +121,7 @@ describe("GET handler", () => {
       theme: "light",
       showLangXP: false,
       compact: false,
+      borderless: false,
     });
   });
 
@@ -129,6 +135,7 @@ describe("GET handler", () => {
       theme: "dark",
       showLangXP: false,
       compact: false,
+      borderless: false,
     });
   });
 
@@ -142,6 +149,7 @@ describe("GET handler", () => {
       theme: "dark",
       showLangXP: true,
       compact: false,
+      borderless: false,
     });
   });
 
@@ -155,6 +163,35 @@ describe("GET handler", () => {
       theme: "dark",
       showLangXP: false,
       compact: true,
+      borderless: false,
+    });
+  });
+
+  it("passes borderless if provided", async () => {
+    getCodeStatsSVG.mockResolvedValue("<svg>test</svg>");
+    const req = createRequest("http://localhost/api/code-stats/badge?user=testuser&borderless=true");
+    await GET(req);
+    expect(getCodeStatsSVG).toHaveBeenCalledWith("testuser", {
+      showProgressBar: true,
+      limit: null,
+      theme: "dark",
+      showLangXP: false,
+      compact: false,
+      borderless: true,
+    });
+  });
+
+  it("defaults borderless to false if not set", async () => {
+    getCodeStatsSVG.mockResolvedValue("<svg>test</svg>");
+    const req = createRequest("http://localhost/api/code-stats/badge?user=testuser");
+    await GET(req);
+    expect(getCodeStatsSVG).toHaveBeenCalledWith("testuser", {
+      showProgressBar: true,
+      limit: null,
+      theme: "dark",
+      showLangXP: false,
+      compact: false,
+      borderless: false,
     });
   });
 

--- a/app/api/code-stats/route.js
+++ b/app/api/code-stats/route.js
@@ -10,6 +10,7 @@ export async function GET(request) {
   const theme = searchParams.get("theme") || "dark";
   const showLangXP = searchParams.get("showLangXP");
   const compact = searchParams.get("compact");
+  const borderless = searchParams.get("borderless");
 
   const validation = validateRequest({ username, theme });
   if (!validation.valid) {
@@ -23,6 +24,7 @@ export async function GET(request) {
       theme,
       showLangXP: showLangXP === "true",
       compact: compact === "true",
+      borderless: borderless === "true",
     });
     return new NextResponse(svg, {
       status: 200,

--- a/app/api/code-stats/tests/route.test.js
+++ b/app/api/code-stats/tests/route.test.js
@@ -35,6 +35,7 @@ describe("GET handler", () => {
       theme: "dark",
       showLangXP: false,
       compact: false,
+      borderless: false,
     });
     expect(res.status).toBe(200);
     expect(res.headers.get("Content-Type")).toBe("image/svg+xml");
@@ -64,6 +65,7 @@ describe("GET handler", () => {
       theme: "dark",
       showLangXP: false,
       compact: false,
+      borderless: false,
     });
   });
 
@@ -77,6 +79,7 @@ describe("GET handler", () => {
       theme: "dark",
       showLangXP: false,
       compact: false,
+      borderless: false,
     });
   });
 
@@ -90,6 +93,7 @@ describe("GET handler", () => {
       theme: "dark",
       showLangXP: false,
       compact: false,
+      borderless: false,
     });
   });
 
@@ -103,6 +107,7 @@ describe("GET handler", () => {
       theme: "dark",
       showLangXP: false,
       compact: false,
+      borderless: false,
     });
   });
 
@@ -116,6 +121,7 @@ describe("GET handler", () => {
       theme: "light",
       showLangXP: false,
       compact: false,
+      borderless: false,
     });
   });
 
@@ -129,6 +135,7 @@ describe("GET handler", () => {
       theme: "dark",
       showLangXP: false,
       compact: false,
+      borderless: false,
     });
   });
 
@@ -142,6 +149,7 @@ describe("GET handler", () => {
       theme: "dark",
       showLangXP: true,
       compact: false,
+      borderless: false,
     });
   });
 
@@ -155,6 +163,35 @@ describe("GET handler", () => {
       theme: "dark",
       showLangXP: false,
       compact: true,
+      borderless: false,
+    });
+  });
+
+  it("passes borderless if provided", async () => {
+    getCodeStatsSVG.mockResolvedValue("<svg>test</svg>");
+    const req = createRequest("http://localhost/api/code-stats?user=testuser&borderless=true");
+    await GET(req);
+    expect(getCodeStatsSVG).toHaveBeenCalledWith("testuser", {
+      showProgressBar: true,
+      limit: null,
+      theme: "dark",
+      showLangXP: false,
+      compact: false,
+      borderless: true,
+    });
+  });
+
+  it("defaults borderless to false if not set", async () => {
+    getCodeStatsSVG.mockResolvedValue("<svg>test</svg>");
+    const req = createRequest("http://localhost/api/code-stats?user=testuser");
+    await GET(req);
+    expect(getCodeStatsSVG).toHaveBeenCalledWith("testuser", {
+      showProgressBar: true,
+      limit: null,
+      theme: "dark",
+      showLangXP: false,
+      compact: false,
+      borderless: false,
     });
   });
 

--- a/app/lib/codeStatsService.js
+++ b/app/lib/codeStatsService.js
@@ -9,6 +9,7 @@ export async function getCodeStatsSVG(username, options = {}) {
     theme = "dark",
     showLangXP = false,
     compact = false,
+    borderless = false,
   } = options;
 
   const langLimit = Math.max(1, Math.min(20, parseInt(limit, 10) || 6));
@@ -28,13 +29,14 @@ export async function getCodeStatsSVG(username, options = {}) {
     .slice(0, langLimit);
 
   if (compact) {
-    return generateCompactSVG(username, totalXP, { theme });
+    return generateCompactSVG(username, totalXP, { theme, borderless });
   }
 
   return generateSVG(username, totalXP, languages, {
     showProgressBar,
     theme,
     showLangXP,
+    borderless,
   });
 }
 

--- a/app/lib/svg.js
+++ b/app/lib/svg.js
@@ -38,7 +38,12 @@ const THEMES = {
 };
 
 export function generateSVG(username, totalXP, topLangs, style = {}) {
-  const { showProgressBar = true, theme = 'dark', showLangXP = false } = style;
+  const {
+    showProgressBar = true,
+    theme = 'dark',
+    showLangXP = false,
+    borderless = false,
+  } = style;
 
   const palette = THEMES[theme] || THEMES.dark;
 
@@ -82,7 +87,7 @@ export function generateSVG(username, totalXP, topLangs, style = {}) {
         text { font-family: Arial, sans-serif; }
         .title { font-weight: bold; }
       </style>
-      <rect width="100%" height="100%" fill="${palette.background}" stroke="${palette.border}" stroke-width="1" rx="5"/>
+      <rect width="100%" height="100%" fill="${palette.background}" stroke="${borderless ? 'none' : palette.border}" stroke-width="${borderless ? 0 : 1}" rx="5"/>
       <text x="50%" y="25" font-size="16" fill="${palette.title}" text-anchor="middle" class="title">Code::Stats</text>
       <text x="50%" y="45" font-size="14" fill="${palette.text}" text-anchor="middle">${username} (Level ${level} – ${formatNumber(progressToNext)} XP to next)</text>
       <text x="10" y="65" font-size="14" fill="${palette.label}">Total XP: ${formatNumber(totalXP)}</text>
@@ -97,7 +102,7 @@ export function generateSVG(username, totalXP, topLangs, style = {}) {
 }
 
 export function generateCompactSVG(username, totalXP, style = {}) {
-  const { theme = 'dark' } = style;
+  const { theme = 'dark', borderless = false } = style;
   const palette = THEMES[theme] || THEMES.dark;
 
   const badgeHeight = 20;
@@ -108,7 +113,7 @@ export function generateCompactSVG(username, totalXP, style = {}) {
 
   return `
     <svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${badgeHeight}">
-      <rect width="100%" height="100%" fill="${palette.background}" stroke="${palette.border}" stroke-width="1" rx="3"/>
+      <rect width="100%" height="100%" fill="${palette.background}" stroke="${borderless ? 'none' : palette.border}" stroke-width="${borderless ? 0 : 1}" rx="3"/>
       <text x="8" y="14" fill="${palette.text}" font-family="Verdana, Geneva, sans-serif" font-size="12">
         ${usernameText} • ${xpText}
       </text>
@@ -120,6 +125,7 @@ export function generateActivitySVG(
   dailyExperience,
   theme = 'light',
   today = new Date(),
+  borderless = false,
 ) {
   const palette = THEMES[theme] || THEMES.dark;
   const oneYearAgo = new Date(today);
@@ -179,7 +185,7 @@ export function generateActivitySVG(
         text { font-family: Arial, sans-serif; }
         .title { font-weight: bold; }
       </style>
-      <rect width="100%" height="100%" fill="${palette.background}" stroke="${palette.border}" stroke-width="1" rx="5"/>
+      <rect width="100%" height="100%" fill="${palette.background}" stroke="${borderless ? 'none' : palette.border}" stroke-width="${borderless ? 0 : 1}" rx="5"/>
       <text x="50%" y="20" font-size="16" fill="${palette.title}" text-anchor="middle" class="title">Activity</text>
       ${squares.join('\n')}
     </svg>

--- a/app/lib/tests/codeStatsService.test.js
+++ b/app/lib/tests/codeStatsService.test.js
@@ -50,6 +50,29 @@ describe("getCodeStatsSVG", () => {
     globalAny.fetch.mockResolvedValueOnce({ ok: false });
     await expect(getCodeStatsSVG("testuser")).rejects.toThrow();
   });
+
+  it("should omit the border when borderless is true", async () => {
+    globalAny.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockUserData,
+    });
+    const svg = await getCodeStatsSVG("testuser", { borderless: true });
+    expect(svg).toContain('stroke="none"');
+    expect(svg).not.toContain('stroke="#fff"');
+  });
+
+  it("should omit the border on compact badges when borderless is true", async () => {
+    globalAny.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockUserData,
+    });
+    const svg = await getCodeStatsSVG("testuser", {
+      compact: true,
+      borderless: true,
+    });
+    expect(svg).toContain('stroke="none"');
+    expect(svg).not.toContain('stroke="#fff"');
+  });
 });
 
 describe("getDailyExperience", () => {

--- a/app/lib/tests/svg.test.js
+++ b/app/lib/tests/svg.test.js
@@ -44,6 +44,21 @@ describe('generateSVG', () => {
     });
     expect(svg).toContain('rect x="10" y="75" width="380" height="10"');
   });
+
+  it('renders with a border by default', () => {
+    const svg = generateSVG(username, totalXP, topLangs);
+    expect(svg).toContain('stroke="#fff"');
+    expect(svg).toContain('stroke-width="1"');
+  });
+
+  it('renders without a border when borderless is true', () => {
+    const svg = generateSVG(username, totalXP, topLangs, {
+      borderless: true,
+    });
+    expect(svg).toContain('stroke="none"');
+    expect(svg).toContain('stroke-width="0"');
+    expect(svg).not.toContain('stroke="#fff"');
+  });
 });
 
 describe('generateCompactSVG', () => {
@@ -61,6 +76,13 @@ describe('generateCompactSVG', () => {
     expect(svg).toContain('stroke="#0d1117"');
     expect(svg).toContain('fill="#24292f"');
     expect(svg).toContain(username);
+  });
+
+  it('renders without a border when borderless is true', () => {
+    const svg = generateCompactSVG(username, totalXP, { borderless: true });
+    expect(svg).toContain('stroke="none"');
+    expect(svg).toContain('stroke-width="0"');
+    expect(svg).not.toContain('stroke="#fff"');
   });
 });
 
@@ -81,6 +103,19 @@ describe('generateActivitySVG', () => {
     const svg = generateActivitySVG([], 'dark');
     expect(svg).toContain('<svg');
     expect(svg).not.toContain('fill-opacity');
+  });
+
+  it('renders with a border by default', () => {
+    const svg = generateActivitySVG([], 'dark');
+    expect(svg).toContain('stroke="#fff"');
+    expect(svg).toContain('stroke-width="1"');
+  });
+
+  it('renders without a border when borderless is true', () => {
+    const svg = generateActivitySVG([], 'dark', new Date(), true);
+    expect(svg).toContain('stroke="none"');
+    expect(svg).toContain('stroke-width="0"');
+    expect(svg).not.toContain('stroke="#fff"');
   });
 
   describe('generateActivitySVG week alignment', () => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -45,6 +45,13 @@ const xpBadges = [
     param: '?compact=true',
     desc: 'Minimal single-line badge showing only total XP.',
   },
+  {
+    src: '/badges/borderless-badge.svg',
+    alt: 'Borderless badge',
+    label: 'Borderless Mode',
+    param: '?borderless=true',
+    desc: 'Remove the badge outline for a cleaner, borderless look.',
+  },
 ];
 
 const features = [

--- a/public/badges/borderless-badge.svg
+++ b/public/badges/borderless-badge.svg
@@ -1,0 +1,14 @@
+
+    <svg width="400" height="180" xmlns="http://www.w3.org/2000/svg">
+      <style>
+        text { font-family: Arial, sans-serif; }
+        .title { font-weight: bold; }
+      </style>
+      <rect width="100%" height="100%" fill="#0d1117" stroke="none" stroke-width="0" rx="5"/>
+      <text x="50%" y="25" font-size="16" fill="#58a6ff" text-anchor="middle" class="title">Code::Stats</text>
+      <text x="50%" y="45" font-size="14" fill="#c9d1d9" text-anchor="middle">Wallyx (Level 43 – 1,055 XP to next)</text>
+      <text x="10" y="65" font-size="14" fill="#8b949e">Total XP: 3,096,545</text>
+      <rect x="10" y="75" width="380" height="10" fill="#30363d" rx="5"/>
+             <rect x="10" y="75" width="377" height="10" fill="#58a6ff" rx="5"/>
+      <text x="10" y="115" font-size="14" fill="#c9d1d9" class="lang-line">Terminal (Zsh): Level 29</text><text x="200" y="115" font-size="14" fill="#c9d1d9" class="lang-line">TypeScript: Level 28</text><text x="10" y="135" font-size="14" fill="#c9d1d9" class="lang-line">Python: Level 9</text><text x="200" y="135" font-size="14" fill="#c9d1d9" class="lang-line">Markdown: Level 6</text><text x="10" y="155" font-size="14" fill="#c9d1d9" class="lang-line">JavaScript: Level 5</text><text x="200" y="155" font-size="14" fill="#c9d1d9" class="lang-line">Shell Script: Level 5</text>
+    </svg>


### PR DESCRIPTION
## Description

New option to remove the border of the badge, also adds the information in the README + adds it to the showcase of the website

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if relevant)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

## Screenshots (if applicable)

<img width="413" height="316" alt="Screenshot 2026-07-01 at 21 41 01" src="https://github.com/user-attachments/assets/31e408e7-0ae4-4e24-94fb-e31aeab52dda" />
